### PR TITLE
Allow temporary credentials as valid schema

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class awsProfileHandler {
             throw new Error('Invalid Input: credentials cannot be omitted nor empty.');
         }
 
-        if (Object.keys(credentials).length !== 2 ||
+        if (Object.keys(credentials).length < 2 ||
             !this.isValidSchema(credentials) &&
             !this.isValidAltSchema(credentials)) {
             throw new Error('Invalid input: credentials schema is invalid.');


### PR DESCRIPTION
Allows the usage of this extension with temporary AWS credentials that also includes the "aws_session_token" parameter